### PR TITLE
Update: to prevent redundancy , the Alias Indicator has been set in minio/docker-compose.yml

### DIFF
--- a/deploy-single-node.sh
+++ b/deploy-single-node.sh
@@ -4,7 +4,7 @@ set -a
 NETWORKS="traefik-net redis pg_net prometheus minio"
 for i in $NETWORKS
 do 
-  docker network create --driver=overlay $i
+  docker network create --attachable=true --driver=overlay $i
 done
 
 source traefik/.env

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ set -a
 NETWORKS="traefik-net redis pg_net prometheus minio"
 for i in $NETWORKS
 do 
-  docker network create --driver=overlay $i
+  docker network create --attachable=true --driver=overlay $i
 done
 
 source traefik/.env

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -54,17 +54,18 @@ x-default-deploy: &default-deploy
     window: 120s
 
 x-default-labels: &default-labels
-  - "traefik.enable=true"
-  - "traefik.docker.network=traefik-net"
-  - "traefik.http.routers.minio.entrypoints=http"
-  - "traefik.http.routers.minio.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-  - "traefik.http.routers.minio.middlewares=https-redirect"
-  - "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https"
-  - "traefik.http.routers.minio-secure.entrypoints=https"
-  - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-  - "traefik.http.routers.minio-secure.tls=true"
-  - "traefik.http.routers.minio-secure.tls.certresolver=mycert"
-  - "traefik.http.services.minio.loadbalancer.server.port=9001"
+  labels:
+    - "traefik.enable=true"
+    - "traefik.docker.network=traefik-net"
+    - "traefik.http.routers.minio.entrypoints=http"
+    - "traefik.http.routers.minio.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
+    - "traefik.http.routers.minio.middlewares=https-redirect"
+    - "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https"
+    - "traefik.http.routers.minio-secure.entrypoints=https"
+    - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
+    - "traefik.http.routers.minio-secure.tls=true"
+    - "traefik.http.routers.minio-secure.tls.certresolver=mycert"
+    - "traefik.http.services.minio.loadbalancer.server.port=9001"
 
 services:
 
@@ -72,24 +73,20 @@ services:
     <<: *default-minio
     hostname: minio-1
     deploy:
-      <<: *default-deploy
+      <<: [*default-deploy, *default-labels]
       placement:
         constraints:
           - node.hostname == sw1
-      labels:
-        <<: *default-labels
         
 
   minio-2:
     <<: *default-minio
     hostname: minio-2
     deploy:
-      <<: *default-deploy
+      <<: [*default-deploy, *default-labels]
       placement:
         constraints:
           - node.hostname == sw2
-      labels:
-        <<: *default-labels
 
   createbuckets:
     image: quay.io/minio/mc:${MINIO_MC_VERSION:-latest}

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -23,8 +23,9 @@ configs:
 x-defaults-minio: &default-minio
   image: quay.io/minio/minio:${MINIO_MINIO_VERSION:-latest}
   environment: 
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+    MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    TZ: Asia/Tehran
   command: 
     - "server"
     - "--console-address"
@@ -35,7 +36,7 @@ x-defaults-minio: &default-minio
     - traefik-net
     - prometheus
   volumes:
-      - minio-data:/data
+    - minio-data:/data
 
 x-default-deploy: &default-deploy
   replicas: 1
@@ -69,7 +70,7 @@ x-default-labels: &default-labels
 
 services:
 
-  minio-1:
+  minio:
     <<: *default-minio
     hostname: minio-1
     deploy:
@@ -91,7 +92,7 @@ services:
   createbuckets:
     image: quay.io/minio/mc:${MINIO_MC_VERSION:-latest}
     depends_on:
-      - minio-1
+      - minio
       - minio-2 
     networks:
       - minio

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -18,107 +18,83 @@ configs:
   backup-policy:
     file: ./backup-policy.json
 
-services:
-  minio:
-    image: quay.io/minio/minio:${MINIO_MINIO_VERSION:-latest}
-    hostname: minio-1
-    networks:
-      - minio
-      - traefik-net
-      - prometheus
-    environment: 
+# Setting YAML indicators , to prevent redundancy.
+
+x-defaults-minio: &default-minio
+  image: quay.io/minio/minio:${MINIO_MINIO_VERSION:-latest}
+  environment: 
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-    command: 
-      - "server"
-      - "--console-address"
-      - ":9001"
-      - "http://minio-{1...2}:9000/data"
-    volumes:
+  command: 
+    - "server"
+    - "--console-address"
+    - ":9001"
+    - "http://minio-{1...2}:9000/data"
+  networks:
+    - minio
+    - traefik-net
+    - prometheus
+  volumes:
       - minio-data:/data
+
+x-default-deploy: &default-deploy
+  replicas: 1
+  update_config:
+    parallelism: 1
+    delay: 30s
+    order: stop-first
+    failure_action: rollback
+  rollback_config:
+    parallelism: 1
+    delay: 30s
+  restart_policy:
+    condition: on-failure
+    delay: 30s
+    max_attempts: 3
+    window: 120s
+
+x-default-labels: &default-labels
+  - "traefik.enable=true"
+  - "traefik.docker.network=traefik-net"
+  - "traefik.http.routers.minio.entrypoints=http"
+  - "traefik.http.routers.minio.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
+  - "traefik.http.routers.minio.middlewares=https-redirect"
+  - "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https"
+  - "traefik.http.routers.minio-secure.entrypoints=https"
+  - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
+  - "traefik.http.routers.minio-secure.tls=true"
+  - "traefik.http.routers.minio-secure.tls.certresolver=mycert"
+  - "traefik.http.services.minio.loadbalancer.server.port=9001"
+
+services:
+
+  minio-1:
+    <<: *default-minio
+    hostname: minio-1
     deploy:
-      replicas: 1
+      <<: *default-deploy
       placement:
         constraints:
           - node.hostname == sw1
-      update_config:
-        parallelism: 1
-        delay: 30s
-        order: stop-first
-        failure_action: rollback
-      rollback_config:
-        parallelism: 1
-        delay: 30s
-      restart_policy:
-        condition: on-failure
-        delay: 30s
-        max_attempts: 3
-        window: 120s
       labels:
-        - "traefik.enable=true"
-        - "traefik.docker.network=traefik-net"
-        - "traefik.http.routers.minio.entrypoints=http"
-        - "traefik.http.routers.minio.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-        - "traefik.http.routers.minio.middlewares=https-redirect"
-        - "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https"
-        - "traefik.http.routers.minio-secure.entrypoints=https"
-        - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-        - "traefik.http.routers.minio-secure.tls=true"
-        - "traefik.http.routers.minio-secure.tls.certresolver=mycert"
-        - "traefik.http.services.minio.loadbalancer.server.port=9001"
+        <<: *default-labels
+        
 
   minio-2:
-    image: quay.io/minio/minio:${MINIO_MINIO_VERSION:-latest}
+    <<: *default-minio
     hostname: minio-2
-    networks:
-      - minio
-      - traefik-net
-      - prometheus
-    environment: 
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-    command: 
-      - "server"
-      - "--console-address"
-      - ":9001"
-      - "http://minio-{1...2}:9000/data"
-    volumes:
-      - minio-data:/data
     deploy:
-      replicas: 1
+      <<: *default-deploy
       placement:
         constraints:
           - node.hostname == sw2
-      update_config:
-        parallelism: 1
-        delay: 30s
-        order: stop-first
-        failure_action: rollback
-      rollback_config:
-        parallelism: 1
-        delay: 30s
-      restart_policy:
-        condition: on-failure
-        delay: 30s
-        max_attempts: 3
-        window: 120s
       labels:
-        - "traefik.enable=true"
-        - "traefik.docker.network=traefik-net"
-        - "traefik.http.routers.minio.entrypoints=http"
-        - "traefik.http.routers.minio.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-        - "traefik.http.routers.minio.middlewares=https-redirect"
-        - "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https"
-        - "traefik.http.routers.minio-secure.entrypoints=https"
-        - "traefik.http.routers.minio-secure.rule=Host(`${MINIO_SUB}.${DOMAIN}`)"
-        - "traefik.http.routers.minio-secure.tls=true"
-        - "traefik.http.routers.minio-secure.tls.certresolver=mycert"
-        - "traefik.http.services.minio.loadbalancer.server.port=9001"
+        <<: *default-labels
 
   createbuckets:
     image: quay.io/minio/mc:${MINIO_MC_VERSION:-latest}
     depends_on:
-      - minio
+      - minio-1
       - minio-2 
     networks:
       - minio


### PR DESCRIPTION
Changes in `deploy.sh` and `deploy-single-node.sh`:
  - add `--attachable` flag and set it to `true` for creating networks.

changes in `minio/docker-compose.yml`:
  - add three YAML Alias indicators named `default-minio`, `default-deploy` and `default-labels` to prevent redundancy.
